### PR TITLE
[Hotfix] Stop the result from being multiplied by the number of clicks.

### DIFF
--- a/src/components/Calculator.svelte
+++ b/src/components/Calculator.svelte
@@ -23,7 +23,7 @@
     class="input"
     bind:value={$url}
     placeholder="Post or Comment URL" />
-<button on:click={calculate($url)} disabled={!$url}>
+<button on:click={calculate($url)} disabled={!$url || $loading}>
     {#if $loading}Loading...{:else}Calculate{/if}
 </button>
 


### PR DESCRIPTION
### Description

If a user clicks on the "Loading..." button after the initial one, the result will
be multiplied by the number of extra clicks the user has inputted.

There are two obvious fixes:
- Have a lock on the `calculate` helper method
- Disable the "Loading..." button

I went for the latter as implementing a lock would add an unnecessary layer of complexity
in my opinion. Disabling the button achieves the same and has no downsides.

### Examples

Scenario 1:
- Click only once (e.g. one click on the "Calculate" button)
- Result: `(val)`

Scenario 2:
- Click three times (e.g. one click on "Calculate", then two on "Loading...")
- Result: `(val) * 3`

Summary:
- Click n times.
- Result: `(val) * n`